### PR TITLE
대기열 진입 시 동시성 제어

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     compileOnly 'org.projectlombok:lombok'
+
+    runtimeOnly 'com.mysql:mysql-connector-j'
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
 
@@ -41,6 +43,7 @@ dependencies {
 
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.8'
+
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: mysql_container
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: root_password  # 루트 사용자 비밀번호 설정
+      MYSQL_DATABASE: example_db           # 기본 데이터베이스 생성
+      MYSQL_USER: user                     # 사용자 계정 생성
+      MYSQL_PASSWORD: user_password        # 사용자 비밀번호 설정
+    restart: always  # 컨테이너 자동 재시작 설정

--- a/src/main/java/com/hhplus/concert/application/lock/NamedLockService.java
+++ b/src/main/java/com/hhplus/concert/application/lock/NamedLockService.java
@@ -1,0 +1,21 @@
+package com.hhplus.concert.application.lock;
+
+import com.hhplus.concert.infra.persistence.lock.NamedLockJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NamedLockService {
+
+    private final NamedLockJpaRepository namedLockRepository;
+
+    public boolean acquireLock(String lockName, int timeout) {
+        Integer result = namedLockRepository.acquireLock(lockName, timeout);
+        return result != null && result == 1;
+    }
+
+    public void releaseLock(String lockName) {
+        namedLockRepository.releaseLock(lockName);
+    }
+}

--- a/src/main/java/com/hhplus/concert/application/token/QueueTokenScheduler.java
+++ b/src/main/java/com/hhplus/concert/application/token/QueueTokenScheduler.java
@@ -1,6 +1,7 @@
 package com.hhplus.concert.application.token;
 
 import com.hhplus.concert.application.config.ConfigService;
+import com.hhplus.concert.application.lock.NamedLockService;
 import com.hhplus.concert.domain.token.QueueToken;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Value;
@@ -15,16 +16,18 @@ public class QueueTokenScheduler {
 
     private final QueueTokenService queueTokenService;
     private final ConfigService configService;
+    private final NamedLockService namedLockService;
 
     @Value("${queue.token.scheduling}")
     private Boolean scheduling;
 
     public QueueTokenScheduler(
             QueueTokenService queueTokenService,
-            ConfigService configService
+            ConfigService configService, NamedLockService namedLockService
     ) {
         this.queueTokenService = queueTokenService;
         this.configService = configService;
+        this.namedLockService = namedLockService;
     }
 
     @Scheduled(initialDelay = 10000, fixedRate = 100000)
@@ -32,10 +35,20 @@ public class QueueTokenScheduler {
         if (!scheduling) {
             return;
         }
-        log.info("Processing queue tokens");
 
-        int count = configService.getMaxQueueTokens();
-        List<QueueToken> queueTokens = queueTokenService.getQueueTokens(count);
-        queueTokenService.processQueueTokens(queueTokens);
+        boolean lockAcquired = namedLockService.acquireLock("processing_queue", 10);
+        if (!lockAcquired) {
+            log.info("Another process is already handling the queue.");
+            return;
+        }
+
+        try {
+            log.info("Processing queue tokens...");
+            int count = configService.getMaxQueueTokens();
+            List<QueueToken> queueTokens = queueTokenService.getQueueTokens(count);
+            queueTokenService.processQueueTokens(queueTokens);
+        } finally {
+            namedLockService.releaseLock("processing_queue");
+        }
     }
 }

--- a/src/main/java/com/hhplus/concert/domain/lock/LockRepository.java
+++ b/src/main/java/com/hhplus/concert/domain/lock/LockRepository.java
@@ -1,0 +1,6 @@
+package com.hhplus.concert.domain.lock;
+
+public interface LockRepository {
+    Integer acquireLock(String lockName, int timeout);
+    void releaseLock(String lockName);
+}

--- a/src/main/java/com/hhplus/concert/infra/persistence/lock/NamedLockJpaEntity.java
+++ b/src/main/java/com/hhplus/concert/infra/persistence/lock/NamedLockJpaEntity.java
@@ -1,0 +1,11 @@
+package com.hhplus.concert.infra.persistence.lock;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class NamedLockJpaEntity {
+
+    @Id
+    private Long id;
+}

--- a/src/main/java/com/hhplus/concert/infra/persistence/lock/NamedLockJpaRepository.java
+++ b/src/main/java/com/hhplus/concert/infra/persistence/lock/NamedLockJpaRepository.java
@@ -1,0 +1,14 @@
+package com.hhplus.concert.infra.persistence.lock;
+
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+
+
+public interface NamedLockJpaRepository extends CrudRepository<NamedLockJpaEntity, Long> {
+
+    @Query(value = "SELECT GET_LOCK(:lockName, :timeout)", nativeQuery = true)
+    Integer acquireLock(String lockName, int timeout);
+
+    @Query(value = "SELECT RELEASE_LOCK(:lockName)", nativeQuery = true)
+    void releaseLock(String lockName);
+}

--- a/src/main/java/com/hhplus/concert/infra/persistence/lock/NamedLockRepositoryImpl.java
+++ b/src/main/java/com/hhplus/concert/infra/persistence/lock/NamedLockRepositoryImpl.java
@@ -1,0 +1,22 @@
+package com.hhplus.concert.infra.persistence.lock;
+
+import com.hhplus.concert.domain.lock.LockRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class NamedLockRepositoryImpl implements LockRepository {
+
+    private final NamedLockJpaRepository namedLockRepository;
+
+    @Override
+    public Integer acquireLock(String lockName, int timeout) {
+        return namedLockRepository.acquireLock(lockName, timeout);
+    }
+
+    @Override
+    public void releaseLock(String lockName) {
+        namedLockRepository.releaseLock(lockName);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,14 +32,13 @@ spring:
     activate:
       on-profile: test
   datasource:
-    url: jdbc:h2:mem:testdb  # H2 데이터베이스 URL (메모리 모드 사용 예시)
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
-  h2:
-    console:
-      enabled: true          # H2 콘솔 활성화
-      path: /h2-console
+    url: jdbc:mysql://localhost:3306/example_db
+    username: user
+    password: user_password
+  jpa:
+    hibernate:
+      ddl-auto: update  # 필요에 따라 create, validate 등으로 변경 가능
+    show-sql: true
 queue:
   token:
     scheduling: true


### PR DESCRIPTION
## 변경사항
- [x] mysql docker compose 파일 추가
- [x] 대기열 진입 시 네임드 락으로 동시성 제어 (스케줄러)

- 네임드 락 사용 이유: 스케줄러는 하나의 jvm에서 돌아갈테니 여러 서버에서 대기열을 동시 제어하는것에 의미를 두었기 때문에 네임드 락 사용했습니다. 